### PR TITLE
Fixed function parameter types in MfPack.Evntprov.pas

### DIFF
--- a/MfPack/Shared/MfPack.Evntprov.pas
+++ b/MfPack/Shared/MfPack.Evntprov.pas
@@ -684,7 +684,7 @@ type
 
 
   function EventEnabled(RegHandle: REGHANDLE;
-                        const EventDescriptor: EVENT_DESCRIPTOR): BOOLEAN; stdcall;
+                        const EventDescriptor: PCEVENT_DESCRIPTOR): BOOLEAN; stdcall;
   {$EXTERNALSYM EventEnabled}
 
 
@@ -748,7 +748,7 @@ type
 
 
   function EventWrite(RegHandle: REGHANDLE;
-                      const EventDescriptor: EVENT_DESCRIPTOR;
+                      const EventDescriptor: PCEVENT_DESCRIPTOR;
                       UserDataCount: ULONG;
                       UserData: PEVENT_DATA_DESCRIPTOR): ULONG; stdcall;
   {$EXTERNALSYM EventWrite}
@@ -772,11 +772,11 @@ type
 
 
   function EventWriteTransfer(RegHandle: REGHANDLE;
-                              EventDescriptor: EVENT_DESCRIPTOR;
-                              const ActivityId: TGUID;
-                              const RelatedActivityId: TGUID;
+                              const EventDescriptor: PCEVENT_DESCRIPTOR;
+                              {_In_opt_} const ActivityId: LPCGUID;
+                              {_In_opt_} const RelatedActivityId: LPCGUID;
                               UserDataCount: ULONG;
-                              UserData: EVENT_DATA_DESCRIPTOR): ULONG; stdcall;
+                              UserData: PEVENT_DATA_DESCRIPTOR): ULONG; stdcall;
   {$EXTERNALSYM EventWriteTransfer}
 
 
@@ -804,13 +804,13 @@ type
 
 
   function EventWriteEx(RegHandle: REGHANDLE;
-                        EventDescriptor: PCEVENT_DESCRIPTOR;
+                        const EventDescriptor: PCEVENT_DESCRIPTOR;
                         Filter: ULONG64;
                         Flags: ULONG;
-                        const ActivityId: LPCGUID;
-                        const RelatedActivityId: LPCGUID;
+                        {_In_opt_} const ActivityId: LPCGUID;
+                        {_In_opt_} const RelatedActivityId: LPCGUID;
                         UserDataCount: ULONG;
-                        UserData: EVENT_DATA_DESCRIPTOR): ULONG; stdcall;
+                        UserData: PEVENT_DATA_DESCRIPTOR): ULONG; stdcall;
   {$EXTERNALSYM EventWriteEx}
 
 


### PR DESCRIPTION
Fixed more function signatures in MfPack.Evntprov.pas.

I tested my changes with my ETW provider.

I was unsure about `PCEVENT_DESCRIPTOR` vs `PEVENT_DESCRIPTOR`.
One is a const pointer to a `EVENT_DESCRIPTOR` struct the other is a plain pointer.
In Delphi both are obviously plain pointers.
I decided to use `PCEVENT_DESCRIPTOR` to match the C signature (same with LPCGUID).
