### PR TITLE
Update WinApi.WinError

### DIFF
--- a/MfPack/src/WinApi.DirectX.DxVa.pas
+++ b/MfPack/src/WinApi.DirectX.DxVa.pas
@@ -1853,7 +1853,11 @@ type
     rcTarget: TRect; // RECT
     rtTarget: REFERENCE_TIME;
     NumSourceSurfaces: DWORD;
-    Alpha: FLOAT;
+    {$IFDEF WIN32}
+    Alpha: Float32;
+    {$ELSE}
+    Alpha: Float64;
+    {$ENDIF}
     Source: array[0..MAX_DEINTERLACE_SURFACES - 1] of DXVA_VideoSample32;
     DestinationFormat: DWORD;
     DestinationFlags: DWORD;

--- a/MfPack/src/WinApi.WinError.pas
+++ b/MfPack/src/WinApi.WinError.pas
@@ -33021,12 +33021,12 @@ const
 // indicate success).
 //
 
-function SUCCEEDED(hr: DWORD): BOOL; inline;
+function SUCCEEDED(hr: HResult): BOOL; inline;
 
 //
 // and the inverse
 //
-function FAILED(hr: DWORD): BOOL; inline;
+function FAILED(hr: HResult): BOOL; inline;
 
 
 //
@@ -71799,12 +71799,12 @@ const
 implementation
 
 
-function SUCCEEDED(hr: DWORD): BOOL; inline;
+function SUCCEEDED(hr: HResult): BOOL; inline;
 begin
   Result := (HResult(hr) >= 0);
 end;
 
-function FAILED(hr: DWORD): BOOL; inline;
+function FAILED(hr: HResult): BOOL; inline;
 begin
   Result := (HResult(hr) < 0);
 end;


### PR DESCRIPTION
Fix parameters for functions SUCCEEDED and FAILED. Previous code raises range check errors with certain checks. E.g - E_POINTER

Also fixed Win64 compilation of WinApi.DirectX.DxVa.