### PR TITLE
Fixes and improvements to SinkWriter Example2

### DIFF
--- a/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/SinkWriterSample.dpr
+++ b/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/SinkWriterSample.dpr
@@ -1,17 +1,8 @@
 program SinkWriterSample;
-
 uses
   {$IFDEF FASTMM}
   FastMM4,
-  {$ENDIF}
-  {$IFDEF MadExcept}
-  madExcept,
-  madLinkDisAsm,
-  madListHardware,
-  madListProcesses,
-  madListModules,
-  {$ENDIF}
-  
+  {$ENDIF }
   Vcl.Forms,
   frmMain in 'frmMain.pas' {MainForm},
   SinkWriterClass in 'SinkWriterClass.pas',
@@ -19,7 +10,6 @@ uses
   Utils in 'Utils.pas';
 
 {$R *.res}
-
 begin
   Application.Initialize;
   Application.MainFormOnTaskbar := True;

--- a/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/Utils.pas
+++ b/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/Utils.pas
@@ -4,7 +4,7 @@
 //
 // Project: MfPack - MediaFoundation
 // Project location: https://sourceforge.net/projects/MfPack
-//                   https://github.com/FactoryXCode/MfPack
+// https://github.com/FactoryXCode/MfPack
 // Module: Utils.pas
 // Kind: Pascal / Delphi unit
 // Release date: 11-12-2012
@@ -17,12 +17,12 @@
 // Initiator(s): Tony (maXcomX), Peter (OzShips)
 // Contributor(s): Tony Kalf (maXcomX), Charles Hacker
 //
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 // CHANGE LOG
 // Date       Person              Reason
 // ---------- ------------------- ----------------------------------------------
 // 28/08/2022 All                 PiL release  SDK 10.0.22621.0 (Windows 11)
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //
 // Remarks: Requires Windows 10 or later.
 //
@@ -35,12 +35,12 @@
 //
 // Todo: -
 //
-//==============================================================================
+// ==============================================================================
 // Source: https://learn.microsoft.com/en-us/windows/win32/medfound/tutorial--using-the-sink-writer-to-encode-video
-//         https://blog.dummzeuch.de/2019/12/12/accessing-bitmap-pixels-with-less-scanline-calls-in-delphi/
+// https://blog.dummzeuch.de/2019/12/12/accessing-bitmap-pixels-with-less-scanline-calls-in-delphi/
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
-//==============================================================================
+// ==============================================================================
 //
 // LICENSE
 //
@@ -59,7 +59,7 @@
 // Commercial users are not allowed to distribute this sourcecode as part of
 // their product.
 //
-//==============================================================================
+// ==============================================================================
 unit Utils;
 
 interface
@@ -76,139 +76,123 @@ uses
   {MediaFoundationApi}
   WinApi.MediaFoundationApi.MfUtils;
 
-
 {$IF SizeOf(Pointer) = 4}
-type NativeInt = Integer;   // Correction for NativeInt on Delphi <= 2007 (8 bytes to 4 bytes).
+
+type
+  NativeInt = Integer;
+  // Correction for NativeInt on Delphi <= 2007 (8 bytes to 4 bytes).
 {$IFEND}
 
 type
 
   pRGBArray = ^TRGBArray;
-  TRGBArray = array[0..32767] of TRGBTriple;
+  TRGBArray = array [0 .. 32767] of TRGBTriple;
 
   // Sets the pointer to the correct pixel offset.
   // See for details: https://blog.dummzeuch.de/2019/12/12/accessing-bitmap-pixels-with-less-scanline-calls-in-delphi/
-  function SetPointer(const aPointer: Pointer;
-                      aOffset: NativeInt): Pointer; inline;
+function SetPointer(const aPointer: Pointer; aOffset: NativeInt)
+  : Pointer; inline;
 
-  // A more precise method to resize a bitmap.
-  // Source:
-  // Charles Hacker
-  // Lecturer in Electronics and Computing
-  // School of Engineering
-  // Griffith University - Gold Coast
-  // Australia
-  procedure ResizeBitmap(aBitmap: TBitmap;
-                         toWidth: Integer;
-                         toHeight: Integer);
+//Now uses Direct2D for resizing. Better quality and much faster.
+procedure ResizeBitmap(aBitmap: TBitmap; toWidth: Integer; toHeight: Integer);
 
-  // Calculates nanoseconds to milliseconds.
-  function NsecToMsec(nSec: Int64): Int64; inline;
+// Calculates nanoseconds to milliseconds.
+function NsecToMsec(nSec: Int64): Int64; inline;
 
-  // Calculates frame duration in 100 nanoseconds units.
-  function CalcFrameDuration(aLatency: UINT32;
-                             aFrameRate: Double): HNSTIME;
+// Calculates frame duration in 100 nanoseconds units.
+function CalcFrameDuration(aLatency: UINT32; aFrameRate: Double): HNSTIME;
 
-  // Performance or latency calculation
-  function PerformanceCounterMilliseconds(AFrequency: Int64): Int64;
+// Performance or latency calculation
+function PerformanceCounterMilliseconds(AFrequency: Int64): Int64;
 
-
-threadvar
-  TimerFrequency: Int64;
-
-
+threadvar TimerFrequency: Int64;
 
 implementation
 
+uses
+  Vcl.Direct2D,
+  WinApi.DirectX.D2D1_1,
+  WinApi.DirectX.DCommon,
+  WinApi.DirectX.D2D1,
+  WinApi.DirectX.DXGIFormat,
+  WinApi.DirectX.DXGIType;
 
-
-function SetPointer(const aPointer: Pointer;
-                    aOffset: NativeInt): Pointer; inline;
+function SetPointer(const aPointer: Pointer; aOffset: NativeInt)
+  : Pointer; inline;
 begin
   Result := Pointer(NativeInt(aPointer) + aOffset);
 end;
 
-
-procedure ResizeBitmap(aBitmap: TBitmap;
-                       toWidth: Integer;
-                       toHeight: Integer);
+procedure ScaleDirect2D1(NewWidth, NewHeight: Integer;
+  const Source, target: TBitmap);
 var
-  xScale, yScale: Single;
-  sFrom_y, sFrom_x: Single;
-  iFrom_y, iFrom_x: Integer;
-  to_y, to_x: Integer;
-  weight_x, weight_y: array[0..1] of Single;
-  weight: Single;
-  new_red, new_green: Integer;
-  new_blue: Integer;
-  total_red, total_green: Single;
-  total_blue: Single;
-  ix, iy: Integer;
-  bTmp: TBitmap;
-  sli, slo: pRGBArray;
-
+  DeviceContext: ID2D1DeviceContext;
+  xscale, yscale: single;
+  bmPitch: Integer;
+  bmProps: D2D1_BITMAP_PROPERTIES1;
+  bmBits: Pointer;
+  D2D1Bitmap: ID2D1Bitmap1;
+  CanvasD2D: TDirect2DCanvas;
 begin
-
-  if (aBitmap.PixelFormat <> pf24bit) then
-    aBitmap.PixelFormat := pf24bit;
-
-  // Create a temporary bitmap
-  bTmp := TBitmap.Create;
-  bTmp.PixelFormat := pf24bit;
-  bTmp.Width := toWidth;
-  bTmp.Height := toHeight;
-
-  xScale := bTmp.Width / (aBitmap.Width - 1);
-  yScale := bTmp.Height / (aBitmap.Height - 1);
-
-  for to_y := 0 to bTmp.Height - 1 do
+  target.PixelFormat := pf32bit;
+  target.SetSize(NewWidth, NewHeight);
+  Source.AlphaFormat := afIgnored;
+  CanvasD2D := TDirect2DCanvas.Create(target.Canvas.Handle,
+    Rect(0, 0, NewWidth, NewHeight));
+  try
+    if Supports(CanvasD2D.RenderTarget, ID2D1DeviceContext, DeviceContext) then
     begin
-      sFrom_y := to_y / yScale;
-      iFrom_y := Trunc(sFrom_y);
-      weight_y[1] := sFrom_y - iFrom_y;
-      weight_y[0] := 1 - weight_y[1];
-
-      for to_x := 0 to bTmp.Width - 1 do
-        begin
-          sFrom_x := to_x / xScale;
-          iFrom_x := Trunc(sFrom_x);
-          weight_x[1] := sFrom_x - iFrom_x;
-          weight_x[0] := 1 - weight_x[1];
-          total_red := 0.0;
-          total_green := 0.0;
-          total_blue := 0.0;
-
-          for ix := 0 to 1 do
-            begin
-              for iy := 0 to 1 do
-                begin
-                  sli := aBitmap.Scanline[ifrom_y + iy];
-                  new_red := sli[iFrom_x + ix].rgbtRed;
-                  new_green := sli[iFrom_x + ix].rgbtGreen;
-                  new_blue := sli[iFrom_x + ix].rgbtBlue;
-                  weight := weight_x[ix] * weight_y[iy];
-                  total_red := total_red + new_red * weight;
-                  total_green := total_green + new_green * weight;
-                  total_blue := total_blue + new_blue * weight;
-                end;
-            end;
-
-         slo := bTmp.ScanLine[to_y];
-         slo[to_x].rgbtRed := Round(total_red);
-         slo[to_x].rgbtGreen := Round(total_green);
-         slo[to_x].rgbtBlue := Round(total_blue);
-        end;
+      bmPitch := -4 * Source.Width;
+      bmProps := Default (D2D1_BITMAP_PROPERTIES1); // ZeroMemory
+      bmProps._pixelFormat.Format := DXGI_FORMAT_B8G8R8A8_UNORM;
+      bmProps._pixelFormat.alphaMode := D2D1_ALPHA_MODE_IGNORE;
+      xscale := NewWidth / Source.Width;
+      yscale := NewHeight / Source.Height;
+      bmBits := Source.ScanLine[0];
+      DeviceContext.SetTransform(D2D_Matrix_3x2_F.Init(xscale, 0, 0,
+        yscale, 0, 0));
+{$IFOPT R+}
+{$DEFINE R_Plus}
+{$R-}
+{$ENDIF}
+      DeviceContext.CreateBitmap(D2SizeU(Source.Width, Source.Height), bmBits,
+        bmPitch, @bmProps, D2D1Bitmap);
+{$IFDEF R_Plus}
+{$R+}
+{$ENDIF}
+      DeviceContext.BeginDraw;
+      DeviceContext.Clear(Default (_D3DColorValue));
+      DeviceContext.DrawImage(D2D1Bitmap, nil, nil,
+        D2D1_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC);
+      // D2D1_INTERPOLATION_MODE_DEFINITION_Cubic);
+      DeviceContext.EndDraw;
+    end
+    else
+    begin
+      CanvasD2D.BeginDraw;
+      CanvasD2D.StretchDraw(Rect(0, 0, NewWidth, NewHeight), Source);
+      CanvasD2D.EndDraw;
     end;
-
-  aBitmap.Width := bTmp.Width;
-  aBitmap.Height := bTmp.Height;
-  aBitmap.Canvas.Draw(0,
-                      0,
-                      bTmp);
-
-  FreeAndNil(bTmp);
+  finally
+    CanvasD2D.Free;
+  end;
 end;
 
+procedure ResizeBitmap(aBitmap: TBitmap; toWidth: Integer; toHeight: Integer);
+var
+  bTmp: TBitmap;
+begin
+  if (aBitmap.PixelFormat <> pf32bit) then
+    aBitmap.PixelFormat := pf32bit;
+  // Create a temporary bitmap
+  bTmp := TBitmap.Create;
+  try
+    ScaleDirect2D1(toWidth, toHeight, aBitmap, bTmp);
+    aBitmap.Assign(bTmp);
+  finally
+    bTmp.Free;
+  end;
+end;
 
 //
 function NsecToMsec(nSec: Int64): Int64; inline;
@@ -217,12 +201,11 @@ begin
 end;
 
 //
-function CalcFrameDuration(aLatency: UINT32;
-                           aFrameRate: Double): HNSTIME;
+function CalcFrameDuration(aLatency: UINT32; aFrameRate: Double): HNSTIME;
 const
   msec = (1000 * 1000); // One millisecond = 1,000,000 nano seconds
 begin
-  Result := Round(ALatency * msec / AFrameRate);
+  Result := Round(aLatency * msec / aFrameRate);
 end;
 
 //
@@ -231,16 +214,17 @@ var
   iCount: Int64;
 
 begin
- if (AFrequency = 0) then
-   Result := 0
- else
-   begin
-     QueryPerformanceCounter(iCount);
-     Result := Round(iCount / AFrequency * 1000);
-   end;
+  if (AFrequency = 0) then
+    Result := 0
+  else
+  begin
+    QueryPerformanceCounter(iCount);
+    Result := Round(iCount / AFrequency * 1000);
+  end;
 end;
 
 initialization
-  QueryPerformanceFrequency(TimerFrequency);
+
+QueryPerformanceFrequency(TimerFrequency);
 
 end.

--- a/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/frmMain.dfm
+++ b/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/frmMain.dfm
@@ -11,10 +11,8 @@ object MainForm: TMainForm
   Font.Name = 'Tahoma'
   Font.Style = []
   Menu = MainMenu
-  OldCreateOrder = False
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
-  PixelsPerInch = 96
   TextHeight = 13
   object lblInfo: TLabel
     Left = 0
@@ -38,7 +36,6 @@ object MainForm: TMainForm
     Width = 667
     Height = 287
     Align = alTop
-    ExplicitLeft = -2
   end
   object MainMenu: TMainMenu
     Left = 46

--- a/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/frmMain.pas
+++ b/MfPack/Samples/SinkWriterToEncodeVideoSample/Example2/frmMain.pas
@@ -116,8 +116,9 @@ type
 
   private
     { Private declarations }
-
-    procedure CheckBitmapFormat(var bmp: TBitmap);
+    //This procedure is now obsolete, we change to the correct format on the fly
+    //without the need to save to file.
+    //procedure CheckBitmapFormat(var bmp: TBitmap);
     // Recieve messages from the sinkwriter.
     procedure OnProcesBmp(var Msg: TMessage); message WM_BITMAP_PROCESSING_MSG;
     procedure OnSinkWriterMsg(var Msg: TMessage); message WM_SINKWRITER_WRITES_BITMAP;
@@ -213,23 +214,6 @@ begin
 end;
 
 
-procedure TMainForm.CheckBitmapFormat(var bmp: TBitmap);
-begin
-  // if we have an unsupported format, we change it to the proper one and use this copy of the original.
-  // The original file will be untouched.
-  if (bmp.PixelFormat <> pf24bit) then
-    begin
-      lblInfo.Caption := Format('Unsupported pixelformat (%s)! The selected file pixelformat has been converted to 24 bit',
-                                [PixelFormatToStr(bmp.PixelFormat)]);
-      bmp.PixelFormat := pf24Bit;
-      FBitmapFiles.Strings[0] := Format('%s_%s.bmp',
-                                        [ChangeFileExt(FBitmapFiles.Strings[0], ''),
-                                         PixelFormatToStr(bmp.PixelFormat)]);
-      bmp.SaveToFile(FBitmapFiles.Strings[0]);
-    end;
-end;
-
-
 procedure TMainForm.mnuSelectOneBitmapClick(Sender: TObject);
 var
   bm: TBitmap;
@@ -244,7 +228,7 @@ try
     begin
       FBitmapFiles.Append(dlgOpenPicture.FileName);
       bm.LoadFromFile(FBitmapFiles.Strings[0]);
-      CheckBitmapFormat(bm);
+      //CheckBitmapFormat(bm);
       imgBitmap.Picture.Assign(bm);
       lblInfo.Caption := 'Select ''Render Video File'' or select ''Video output'' to configure the video.';
       mnuRender.Enabled := True;
@@ -295,7 +279,7 @@ begin
         {$WARN SYMBOL_PLATFORM ON}
           begin
             repeat
-              DirList.Add(SearchRec.Name); //Fill the list
+              DirList.Add(IncludeTrailingPathDelimiter(Path)+SearchRec.Name); //Fill the list
             until FindNext(SearchRec) <> 0;
             FindClose(SearchRec);
           end;
@@ -311,12 +295,12 @@ begin
 
         bm := TBitmap.Create();
         // Check if each bitmap pixelformat is 24bit and change it when not.
-        for i := 0 to FBitmapFiles.Count - 1 do
-          begin
-            bm.FreeImage();
-            bm.LoadFromFile(FBitmapFiles[i]);
-            CheckBitmapFormat(bm);
-          end;
+//        for i := 0 to FBitmapFiles.Count - 1 do
+//          begin
+//            bm.FreeImage();
+//            bm.LoadFromFile(FBitmapFiles[i]);
+//            CheckBitmapFormat(bm);
+//          end;
 
       finally
 
@@ -382,6 +366,10 @@ begin
                              FSinkWriter.SinkWriterParams.pwcVideoFileName]);
   lblInfo.Update();
 end;
+
+initialization
+
+ReportMemoryLeaksOnShutDown:=true;
 
 
 end.


### PR DESCRIPTION
Fixed runtime error on selecting multiple bitmaps. Speedup of bitmap resizing using D2D1_1
Reduced memory usage by using only one frame buffer Eliminated need for saving corrected bitmaps to file.