### PR TITLE
Add video rotation option

### DIFF
--- a/MfPack/Samples/MfSimpleCapture/MfDeviceCaptureClass.pas
+++ b/MfPack/Samples/MfSimpleCapture/MfDeviceCaptureClass.pas
@@ -150,6 +150,8 @@ type
     // Colorkey needed to draw transparent on the videosurface.
     FBGColor: COLORREF;
 
+    FRotation : Integer;
+
     // interfaces
     m_pSession:          IMFMediaSession;           // Media Session.
     m_pSource:           IMFMediaSource;            // Media Source.
@@ -226,6 +228,10 @@ type
     // Get or set the videosurface
     procedure SetVideoScreen(val: HWND);
     function GetVideoScreen(): HWND;
+
+    procedure SetRotation(AValue : Integer);
+    function SetStreamRotation(const ASource : IMFMediaSource; AStreamIndex : Integer; ARotation : Integer) : Boolean;
+
     // Get the video Normalized Rectangle
     function GetVideoRectangle(): TRECT;
 
@@ -263,6 +269,8 @@ type
     // Capture methods
     function PrepareSession(): HRESULT;  // Prepares the session for recording
     function VideoDetected(): Boolean; // returns m_bHasVideo;
+
+    property Rotation : Integer read FRotation write SetRotation;
 
     property State: TCeState read m_State write m_State;
     property Request: TRequest read m_Request write m_Request;
@@ -493,6 +501,7 @@ begin
   m_bHasVideo := False;
   m_pwszSymbolicLink := nil;
   m_cchSymbolicLink := 0;
+  FRotation := 0;
 
   hr := Initialize();
 
@@ -513,7 +522,6 @@ var
   pCaptureEngine: TMfCaptureEngine;
 
 begin
-
   pCaptureEngine := TMfCaptureEngine.Create(hVideo,
                                             hMainForm);
 
@@ -1199,6 +1207,8 @@ try
   if FAILED(hr) then
     dwSessionCaps := $0001;
 
+  SetStreamRotation(m_pSource, 0, FRotation);
+
   if SUCCEEDED(hr) then
     begin
       //
@@ -1394,13 +1404,43 @@ begin
   Result := m_bHasVideo;
 end;
 
+procedure TMfCaptureEngine.SetRotation(AValue : Integer);
+begin
+  if AValue <> FRotation then
+  begin
+    FRotation := AValue;
+    if Assigned(m_pSource) then
+      PrepareSession;
+  end;
+end;
+
+function TMfCaptureEngine.SetStreamRotation(const ASource : IMFMediaSource; AStreamIndex : Integer; ARotation : Integer) : Boolean;
+var
+  pPD : IMFPresentationDescriptor;
+  pSD : IMFStreamDescriptor;
+  pHandler : IMFMediaTypeHandler;
+  pMediaType : IMFMediaType;
+  fSelected : BOOL;
+begin
+  // Calls can be combined if no additional error handling is added at each stage.
+  Result := Succeeded(ASource.CreatePresentationDescriptor(pPD)) and Succeeded(pPD.GetStreamDescriptorByIndex(AStreamIndex, fSelected, pSD));
+
+  if Result then
+    Result := Succeeded(pSD.GetMediaTypeHandler(pHandler));
+
+  if Result then
+    Result := Succeeded(pHandler.GetCurrentMediaType(pMediaType));
+
+   if Result then
+    Result := Succeeded(pMediaType.SetUINT32(MF_MT_VIDEO_ROTATION, ARotation));
+end;
+
 // Sets the desired clipping window/control
 procedure TMfCaptureEngine.SetVideoScreen(val: HWND);
 begin
   if Assigned(m_pVideoDisplay) then
     m_pVideoDisplay.SetVideoWindow(val);
 end;
-
 
 function TMfCaptureEngine.GetVideoScreen(): HWND;
 begin

--- a/MfPack/Samples/MfSimpleCapture/frmSimpleCapture.dfm
+++ b/MfPack/Samples/MfSimpleCapture/frmSimpleCapture.dfm
@@ -2,29 +2,34 @@ object Frm_SimpleCapture: TFrm_SimpleCapture
   Left = 0
   Top = 0
   Caption = 'MfSimpleCapture example'
-  ClientHeight = 344
-  ClientWidth = 406
+  ClientHeight = 343
+  ClientWidth = 402
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   Position = poScreenCenter
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
   OnPaint = FormPaint
-  PixelsPerInch = 96
   TextHeight = 13
   object pnlControls: TPanel
     Left = 0
-    Top = 295
-    Width = 406
+    Top = 294
+    Width = 402
     Height = 49
     Align = alBottom
     BevelInner = bvLowered
     TabOrder = 0
+    object lblRotation: TLabel
+      Left = 216
+      Top = 24
+      Width = 48
+      Height = 13
+      Caption = 'Rotation: '
+    end
     object Button1: TButton
       Left = 10
       Top = 13
@@ -43,12 +48,28 @@ object Frm_SimpleCapture: TFrm_SimpleCapture
       TabOrder = 1
       OnClick = butGetDeviceClick
     end
+    object cboRotation: TComboBox
+      Left = 272
+      Top = 17
+      Width = 97
+      Height = 21
+      Style = csDropDownList
+      ItemIndex = 0
+      TabOrder = 2
+      Text = '0'
+      OnChange = HandleRotationChanged
+      Items.Strings = (
+        '0'
+        '90'
+        '180'
+        '270')
+    end
   end
   object pnlVideo: TPanel
     Left = 0
     Top = 0
-    Width = 406
-    Height = 295
+    Width = 402
+    Height = 294
     Align = alClient
     AutoSize = True
     BevelOuter = bvNone

--- a/MfPack/Samples/MfSimpleCapture/frmSimpleCapture.pas
+++ b/MfPack/Samples/MfSimpleCapture/frmSimpleCapture.pas
@@ -109,12 +109,15 @@ type
     Button1: TButton;
     butGetDevice: TButton;
     pnlVideo: TPanel;
+    cboRotation: TComboBox;
+    lblRotation: TLabel;
     procedure FormCreate(Sender: TObject);
     procedure FormPaint(Sender: TObject);
     procedure pnlVideoResize(Sender: TObject);
     procedure butGetDeviceClick(Sender: TObject);
     procedure Button1Click(Sender: TObject);
     procedure FormCloseQuery(Sender: TObject; var CanClose: Boolean);
+    procedure HandleRotationChanged(Sender: TObject);
 
   private
     { Private declarations }
@@ -256,6 +259,11 @@ begin
     end;
 end;
 
+
+procedure TFrm_SimpleCapture.HandleRotationChanged(Sender: TObject);
+begin
+  MfDeviceCapture.Rotation := StrToInt(cboRotation.Text);
+end;
 
 // Message listener
 // Listen for WM_DEVICECHANGE messages. The lParam message parameter is a pointer to a DEV_BROADCAST_HDR structure.


### PR DESCRIPTION
Update MfSimpleCapture to demonstrate the use of rotating a video stream. Useful for handheld devices.
I could not find any existing examples of how to use the MF_MT_VIDEO_ROTATION attribute.
As far as I can tell the playback topology needs to be recreated after setting the rotation, but I have not looked into that in detail, so it is possible optimisations can be made.