### PR TITLE
Fix IsRateSupported parameter

### DIFF
--- a/MfPack/src/WinApi.MediaFoundationApi.MfIdl.pas
+++ b/MfPack/src/WinApi.MediaFoundationApi.MfIdl.pas
@@ -2769,7 +2769,7 @@ type
 
     function IsRateSupported(const fThin: BOOL;
                              const flRate: FLOAT;
-                             var pflNearestSupportedRate: FLOAT): HResult; stdcall;
+                             pflNearestSupportedRate: PFLOAT = nil): HResult; stdcall;
 
   end;
   IID_IMFRateSupport = IMFRateSupport;

--- a/MfPack/src/WinApi.MediaFoundationApi.MfIdl.pas
+++ b/MfPack/src/WinApi.MediaFoundationApi.MfIdl.pas
@@ -2769,7 +2769,7 @@ type
 
     function IsRateSupported(const fThin: BOOL;
                              const flRate: FLOAT;
-                             pflNearestSupportedRate: FLOAT = 0): HResult; stdcall;
+                             var pflNearestSupportedRate: FLOAT): HResult; stdcall;
 
   end;
   IID_IMFRateSupport = IMFRateSupport;


### PR DESCRIPTION
I was encountered access violations when calling IsRateSupported, so looked into the method declaration.
AV's are resolved after making this change.

Although the doco mentions the pflNearestSupportedRate parameter can be NULL. Not sure if this is scenario you have dealt with elsewhere in the translations? @FactoryXCode 

See https://learn.microsoft.com/en-us/windows/win32/api/mfidl/nf-mfidl-imfratesupport-isratesupported
