### PR TITLE
Fixed wrong parameter definition of DrawBitmap

### DIFF
--- a/MfPack/src/WinApi.DirectX.D2d1_1.pas
+++ b/MfPack/src/WinApi.DirectX.D2d1_1.pas
@@ -1352,9 +1352,9 @@ type
                               targetOffset: PD2D1_POINT_2F = nil); stdcall;
 
     procedure DrawBitmap(bitmap: ID2D1Bitmap;
-                         destinationRectangle: D2D1_RECT_F;
-                         opacity: Single;
-                         interpolationMode: D2D1_INTERPOLATION_MODE;
+                         destinationRectangle: PD2D1_RECT_F = nil;
+                         opacity: Single = 1.0;
+                         interpolationMode: D2D1_INTERPOLATION_MODE = D2D1_BITMAP_INTERPOLATION_MODE_LINEAR;
                          sourceRectangle: PD2D1_RECT_F = nil;
                          perspectiveTransform: PD2D1_MATRIX_4X4_F = nil); stdcall;
 


### PR DESCRIPTION
destinationRectangle is a pointer to D2D1_RECT_F. Added predefined value to make it look more like the DrawBitmap definition in WinApi.DirectX.D2D1.pas.

Without this changes "D2DDeviceContext.DrawBitmap(D2DBitmap, Rect1, 1, D2D1_INTERPOLATION_MODE_DEFINITION_LINEAR)"  will fail with "D2D DEBUG ERROR - The parameter [interpolationMode] with value [1133903872] for ID2D1DeviceContext::DrawBitmap is not a valid enumeration value".

With this changes D2DDeviceContext.DrawBitmap(D2DBitmap, @Rect1, 1, D2D1_INTERPOLATION_MODE_DEFINITION_LINEAR) works as expected.

Tested with Delphi 11.1 under Windows 11 24H2 32bit and 64bit.